### PR TITLE
Don't assume the presence of the debugging lib

### DIFF
--- a/gio/gio-sharp-2.0.pc.in
+++ b/gio/gio-sharp-2.0.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 assemblies_dir=${libdir}/gio-sharp
 gapidir=${prefix}/share/gapi-2.0
-Libraries=${assemblies_dir}/gio-sharp.dll ${assemblies_dir}/gio-sharp.dll.mdb
+Libraries=${assemblies_dir}/gio-sharp.dll
 
 Name: GIO#
 Description: GIO# - GIO .NET Binding


### PR DESCRIPTION
Hiya,

This is a small change to not assume the presence of the .mdb library in gio-sharp's pcfile. It's not at all necessary that this is present. Consumers should instead check for $asm.mdb and copy it if it's there.

We've applied this patch in Debian/Ubuntu already.

Cheers.
